### PR TITLE
fix: Compilation problems detected on macos, linux

### DIFF
--- a/simdb.hpp
+++ b/simdb.hpp
@@ -485,9 +485,11 @@ public:
     }
   }
 
-  bool headCmpEx(u64* expected, au64 desired)
+  bool headCmpEx(u64* expected, u64* desired)
   {
     using namespace std;
+
+    au64 desired_au64 = au64(*desired);
 
     //return atomic_compare_exchange_strong_explicit(
     //  s_h, (volatile au64*)&expected, desired,
@@ -499,7 +501,7 @@ public:
     //);
 
     return atomic_compare_exchange_strong_explicit(
-      s_h, expected, desired,
+      s_h, expected, desired_au64,
       memory_order_seq_cst, memory_order_seq_cst
     );
   }
@@ -514,8 +516,8 @@ public:
 
       nxtHead.idx  =  s_lv[curHead.idx];
       nxtHead.ver  =  curHead.ver==NXT_VER_SPECIAL? 1  :  curHead.ver+1;
-    }while( !headCmpEx( &curHead.asInt, nxtHead.asInt) );
-    //}while( !headCmpEx(curHead.asInt, nxtHead.asInt) );
+    }while( !headCmpEx( &curHead.asInt, &nxtHead.asInt) );
+    //}while( !headCmpEx(curHead.asInt, &nxtHead.asInt) );
     //}while( !s_h->compare_exchange_strong(curHead.asInt, nxtHead.asInt) );
 
     return curHead.idx;
@@ -534,8 +536,8 @@ public:
       prevHead     =  curHead;
       nxtHead.idx  =  s_lv[curHead.idx];
       nxtHead.ver  =  curHead.ver==NXT_VER_SPECIAL? 1  :  curHead.ver+1;
-    }while( !headCmpEx( &curHead.asInt, nxtHead.asInt) );
-    //}while( !headCmpEx(curHead.asInt, nxtHead.asInt) );
+    }while( !headCmpEx( &curHead.asInt, &nxtHead.asInt) );
+    //}while( !headCmpEx(curHead.asInt, &nxtHead.asInt) );
     //}while( !s_h->compare_exchange_strong(curHead.asInt, nxtHead.asInt) );
 
     //s_lv[prev] = curHead.idx;
@@ -551,8 +553,8 @@ public:
       retIdx = s_lv[idx] = curHead.idx;
       nxtHead.idx  =  idx;
       nxtHead.ver  =  curHead.ver + 1;
-    }while( !headCmpEx( &curHead.asInt, nxtHead.asInt) );
-    //}while( !headCmpEx(curHead.asInt, nxtHead.asInt) );
+    }while( !headCmpEx( &curHead.asInt, &nxtHead.asInt) );
+    //}while( !headCmpEx(curHead.asInt, &nxtHead.asInt) );
     //}while( !s_h->compare_exchange_strong(curHead.asInt, nxtHead.asInt) );
 
     return retIdx;
@@ -570,8 +572,8 @@ public:
       //atomic_store( (au32*)&(s_lv[en]), curHead.idx);
       nxtHead.idx  =  st;
       nxtHead.ver  =  curHead.ver + 1;
-    }while( !headCmpEx( &curHead.asInt, nxtHead.asInt) );
-    //}while( !headCmpEx(curHead.asInt, nxtHead.asInt) );
+    }while( !headCmpEx( &curHead.asInt, &nxtHead.asInt) );
+    //}while( !headCmpEx(curHead.asInt, &nxtHead.asInt) );
     //}while( !s_h->compare_exchange_strong(curHead.asInt, nxtHead.asInt) );
 
     return retIdx;
@@ -1344,7 +1346,7 @@ public:
   }
 
   template<class FUNC, class T>
-  bool      runMatch(const void *const key, u32 klen, u32 hash, FUNC f, T defaultRet = decltype(f(vi))() )       const 
+  bool      runMatch(const void *const key, u32 klen, u32 hash, FUNC f, T defaultRet = decltype(f(VerIdx()))() )       const 
   {
     using namespace std;
     


### PR DESCRIPTION
Fix issue: https://github.com/LiveAsynchronousVisualizedArchitecture/simdb/issues/4 and https://github.com/LiveAsynchronousVisualizedArchitecture/simdb/issues/8

- headCmpEx() changed to not use the atomic copy operator that is set to deleted in macos  (Xcode 14). Fixing the following error:

```sh
./simdb.hpp:554:41: error: copying parameter of type 'std::atomic<u64>' (aka 'atomic<unsigned long long>') invokes deleted constructor
    }while( !headCmpEx( &curHead.asInt, nxtHead.asInt) );
```

- changing `decltype(f(vi))` to `decltype(f(VerIdx()))` in runMatch to fix the following error

```sh
./simdb.hpp:1349:99: error: use of undeclared identifier 'vi'
  bool      runMatch(const void *const key, u32 klen, u32 hash, FUNC f, T defaultRet = decltype(f(vi))() )       const
```

The example is tested and works perfectly. My platform (Macos m1, Xcode14)
